### PR TITLE
Fix invalid module name in the groups.example.yml

### DIFF
--- a/groups.example.yml
+++ b/groups.example.yml
@@ -30,7 +30,7 @@ groups:
       storage-lvm-physical-volume: {}
     commands:
       logs: {}
-      shell: {}
+      linux-shell: {}
       shutdown: {}
       reboot: {}
       linux-packages-clean: {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::redundant_field_names)]
 #![allow(clippy::needless_return)]
+#![forbid(unsafe_code)]
 
 mod module;
 mod host_manager;


### PR DESCRIPTION
I tried to start it up at my machine, but it gave me out a panic that said `Module shell is not found`. I checked the modules and found this one, I hope that I didn't mistake it for something else.

Also this PR adds `#![forbid(unsafe_code)]` to the start of `main.rs`. It doesn't really have much meaning (other than banning unsafe code (a.k.a. rust memsafe) ), but I am unsure on how to selectively apply commits to a PR here so here's that.